### PR TITLE
fix example to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ def test_my_html(self):
         heading('My Document'),
         div(
             text('This is some text.'),
-            elem('table', id='important-table)))
-
-    self.assertTrue(html_match(spec, html_src))
+            elem('table', id='important-table')))
+    result = html_match(spec, html_src)
+    self.assertTrue(result.passed)
 ```
 
 Now, even if there are changes to the HTML that we don't care about, our test


### PR DESCRIPTION
the README.md gives you BAD example.  If you follow the example, you will never have a failure of a test because the returned object is always True.

It also is missing a closing quote.